### PR TITLE
Updated Json gem version

### DIFF
--- a/ApiWrapperFor8x8.gemspec
+++ b/ApiWrapperFor8x8.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bundler" , ">= 1.0.0"
   spec.add_dependency "httparty", ">= 0.9.0"
-  spec.add_dependency "json"    , "~> 1.8.0"
+  spec.add_dependency "json"    , "~> 2.3"
 
 end


### PR DESCRIPTION
Updated JSON version from 1.8.0 to 2.3.1 because of security risk

Unsafe object creation in json RubyGem
https://github.com/advisories/GHSA-jphg-qwrw-7w9g